### PR TITLE
Bindcraft logging configuration

### DIFF
--- a/modules/bindcraft.nf
+++ b/modules/bindcraft.nf
@@ -3,6 +3,7 @@ process BINDCRAFT {
 
     publishDir path: "${params.outdir}/bindcraft/batches/${batch_id}", pattern: 'results/**', mode: 'copy'
     publishDir path: "${params.outdir}/bindcraft/batches/${batch_id}", pattern: '*.{pdb,pdb.gz,json}', mode: 'copy'
+    publishDir path: "${params.outdir}/bindcraft/batches/${batch_id}", pattern: 'bindcraft.log', mode: 'copy'
     publishDir(
         path: "${params.outdir}/bindcraft/accepted",
         pattern: 'results/Accepted/*.{pdb,pdb.gz}',
@@ -30,6 +31,7 @@ process BINDCRAFT {
     path 'results/trajectory_stats.csv', optional: true,           emit: trajectory_stats_csv
     path 'results/mpnn_design_stats.csv', optional: true,          emit: mpnn_design_stats_csv
     path 'results/failure_csv.csv', optional: true,                emit: failure_csv
+    path 'bindcraft.log',                                          emit: log
     path '*.json', followLinks: true, includeInputs: true, optional: true, emit: settings_files
     path '*.pdb', followLinks: true, includeInputs: true, optional: true, emit: input_pdb
     path 'results/**', emit: all_results
@@ -92,7 +94,7 @@ with open("${modified_advanced_settings_filename}", "w") as f:
         --filters /app/BindCraft/settings_filters/default_filters.json \
         --advanced ${modified_advanced_settings_filename} \
         --filters ${modified_filters_filename} \
-        ${task.ext.args ?: ''}
+        ${task.ext.args ?: ''} 2>&1 | tee bindcraft.log
 
     if [[ ${compress_html} == "true" ]]; then
         find ./results -type f -name '*.html' -exec gzip -9 {} +


### PR DESCRIPTION
Capture BindCraft process stdout/stderr to `bindcraft.log` and publish it to the batch results directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c18abf9-f7aa-47c1-89ef-03f155dd5aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c18abf9-f7aa-47c1-89ef-03f155dd5aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

