### PR TITLE
Fix RF3 ipSAE format detection and pLDDT indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BindCraft report accept summary: trajectory outcomes (Relaxed / LowConfidence / Clashing) now sum to total trajectories; Accepted / Rejected MPNN designs are shown separately.
 - BindCraft: process now fails (non-zero exit) when `bindcraft.py` crashes; previously `| tee bindcraft.log` masked the Python exit code so Nextflow marked the task COMPLETED.
 - `bin/ipsae.py` RF3 support: treat RF3 as its own input format (not a nested AF3 mode), read the scalar `iptm` from RF3 summary JSON instead of the AF3-only `chain_pair_iptm` matrix, auto-detect RF3 vs AF3 from summary contents, and index per-atom pLDDT correctly for RF3 mmCIF files (atoms numbered from 0).
+- `bin/ipsae.py`: unwrap list-wrapped native AF2 `pae_model_*.json` so ipSAE can read `predicted_aligned_error`.
+- `bin/ipsae.py`: accept Protenix full-data JSON (`token_pair_pae`, `atom_plddt`, `*_summary_confidence_sample_N.json`) and scale 0–1 pLDDT like RF3.
 
 ## [0.3.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - BindCraft report accept summary: trajectory outcomes (Relaxed / LowConfidence / Clashing) now sum to total trajectories; Accepted / Rejected MPNN designs are shown separately.
 - BindCraft: process now fails (non-zero exit) when `bindcraft.py` crashes; previously `| tee bindcraft.log` masked the Python exit code so Nextflow marked the task COMPLETED.
+- `bin/ipsae.py` RF3 support: treat RF3 as its own input format (not a nested AF3 mode), read the scalar `iptm` from RF3 summary JSON instead of the AF3-only `chain_pair_iptm` matrix, auto-detect RF3 vs AF3 from summary contents, and index per-atom pLDDT correctly for RF3 mmCIF files (atoms numbered from 0).
 
 ## [0.3.0] - 2026-07-09
 

--- a/bin/ipsae.py
+++ b/bin/ipsae.py
@@ -60,6 +60,34 @@ np.set_printoptions(
 SUPPORTED_FORMATS = ("af2", "af3", "boltz", "rf3")
 
 
+def unwrap_json_object(data):
+    """Return a dict from JSON that may be wrapped as a one-element list.
+
+    Native AlphaFold2 writes ``pae_model_*.json`` as
+    ``[{predicted_aligned_error: [...], ...}]`` rather than a bare object.
+    """
+    if isinstance(data, list):
+        if len(data) == 1 and isinstance(data[0], dict):
+            return data[0]
+        raise ValueError(
+            "Expected a JSON object or a one-element list of objects, "
+            f"got list of length {len(data)}"
+        )
+    if isinstance(data, dict):
+        return data
+    raise ValueError(f"Expected a JSON object, got {type(data).__name__}")
+
+
+def normalize_token_pae_json(data: dict) -> dict:
+    """Alias Protenix full-data keys onto the AF3/RF3 names ipSAE expects."""
+    out = dict(data)
+    if "atom_plddts" not in out and "atom_plddt" in out:
+        out["atom_plddts"] = out["atom_plddt"]
+    if "pae" not in out and "token_pair_pae" in out:
+        out["pae"] = out["token_pair_pae"]
+    return out
+
+
 def summary_confidences_path(pae_file_path: str) -> str | None:
     """Map an AF3/RF3 confidences JSON path to its summary_confidences sibling.
 
@@ -70,7 +98,16 @@ def summary_confidences_path(pae_file_path: str) -> str | None:
     if "summary_confidences" in name:
         summary_name = name
     elif "full_data" in name:
-        summary_name = name.replace("full_data", "summary_confidences")
+        # AF3: full_data -> summary_confidences. Protenix uses the singular
+        # summary_confidence in *_full_data_sample_N.json.
+        af3_name = name.replace("full_data", "summary_confidences")
+        ptx_name = name.replace("full_data", "summary_confidence")
+        if os.path.exists(os.path.join(directory, af3_name)):
+            summary_name = af3_name
+        elif os.path.exists(os.path.join(directory, ptx_name)):
+            summary_name = ptx_name
+        else:
+            summary_name = af3_name
     elif "confidences" in name:
         summary_name = name.replace("confidences", "summary_confidences")
     else:
@@ -609,6 +646,9 @@ def main():
                 with open(pae_file_path, "r") as file:
                     data = json.load(file)
 
+            if not isinstance(data, dict):
+                data = unwrap_json_object(data)
+
             if "iptm" in data:
                 iptm_af2 = float(data["iptm"])
             else:
@@ -629,6 +669,12 @@ def main():
                 pae_matrix = np.array(data["pae"])
             elif "predicted_aligned_error" in data:
                 pae_matrix = np.array(data["predicted_aligned_error"])
+            else:
+                print(
+                    "no PAE data in AF2 json file "
+                    "(expected 'pae' or 'predicted_aligned_error'); quitting"
+                )
+                sys.exit()
 
         else:
             print("AF2 PAE file does not exist: ", pae_file_path)
@@ -708,9 +754,11 @@ def main():
             print(f"{label} PAE file does not exist: ", pae_file_path)
             sys.exit()
 
+        data = normalize_token_pae_json(data)
         atom_plddts = np.array(data["atom_plddts"])
-        if rf3:
-            atom_plddts = atom_plddts * 100.0  # RF3 reports pLDDT on 0-1, AF3 on 0-100
+        # RF3 and Protenix report per-atom pLDDT on 0-1; AF3 uses 0-100.
+        if atom_plddts.size and np.nanmax(atom_plddts) <= 1.0:
+            atom_plddts = atom_plddts * 100.0
         plddt = atom_plddts[CA_atom_num]  # pull out residue plddts from Calpha atoms
         cb_plddt = atom_plddts[
             CB_atom_num

--- a/bin/ipsae.py
+++ b/bin/ipsae.py
@@ -15,6 +15,8 @@
 # Based on: https://github.com/DunbrackLab/IPSAE
 #
 # Modified by Andrew Perry, 2025
+# Added RosettaFold3 (rf3) support: AF3-shaped confidences, but pLDDT on 0-1,
+# mmCIF atoms numbered from 0, and a single scalar iptm instead of chain_pair_iptm.
 #
 # ipsae.py
 # script for calculating the ipSAE score for scoring pairwise protein-protein interactions in AlphaFold2 and AlphaFold3 models
@@ -54,6 +56,69 @@ import numpy as np
 np.set_printoptions(
     threshold=np.inf
 )  # for printing out full numpy arrays for debugging
+
+SUPPORTED_FORMATS = ("af2", "af3", "boltz", "rf3")
+
+
+def summary_confidences_path(pae_file_path: str) -> str | None:
+    """Map an AF3/RF3 confidences JSON path to its summary_confidences sibling.
+
+    Only the basename is rewritten — parent directories can themselves contain
+    "confidences" (RF3 writes ``<id>_rf3/<id>_rf3_confidences.json``).
+    """
+    directory, name = os.path.split(pae_file_path)
+    if "summary_confidences" in name:
+        summary_name = name
+    elif "full_data" in name:
+        summary_name = name.replace("full_data", "summary_confidences")
+    elif "confidences" in name:
+        summary_name = name.replace("confidences", "summary_confidences")
+    else:
+        return None
+    return os.path.join(directory, summary_name)
+
+
+def detect_cif_json_format(pae_file_path: str) -> str:
+    """Distinguish RF3 from AF3: both pair an mmCIF model with a confidences JSON.
+
+    AF3 summaries carry a per-chain-pair ``chain_pair_iptm`` matrix; RF3 writes a
+    single interface-wide ``iptm`` scalar alongside chain_pair_pae/pde matrices.
+    """
+    summary_path = summary_confidences_path(pae_file_path)
+    if summary_path is None or not os.path.exists(summary_path):
+        return "af3"
+    try:
+        with open(summary_path, "r") as file:
+            summary = json.load(file)
+    except (OSError, ValueError):
+        return "af3"
+    if "chain_pair_iptm" in summary:
+        return "af3"
+    if "chain_pair_pde" in summary or "overall_pde" in summary:
+        return "rf3"
+    return "af3"
+
+
+def resolve_input_format(input_format: str, struct_name: str, pae_file_path: str) -> str:
+    """Resolve an explicit format request, or guess one from the input files."""
+    if input_format not in ("auto",) + SUPPORTED_FORMATS:
+        raise ValueError(
+            f"Unknown input format {input_format!r}; "
+            f"expected auto or one of {', '.join(SUPPORTED_FORMATS)}"
+        )
+    if input_format != "auto":
+        return input_format
+
+    if pae_file_path.endswith(".npz"):
+        return "boltz"
+    if ".cif" in struct_name and pae_file_path.endswith(".json"):
+        return detect_cif_json_format(pae_file_path)
+    if ".pdb" in struct_name:
+        return "af2"
+    raise ValueError(
+        f"Cannot determine input format from structure {struct_name!r} "
+        f"and PAE file {os.path.basename(pae_file_path)!r}"
+    )
 
 
 def main():
@@ -95,9 +160,13 @@ def main():
     )
     parser.add_argument(
         "--format",
-        choices=("auto", "af2", "af3", "boltz", "rf3"),
+        choices=("auto",) + SUPPORTED_FORMATS,
         default="auto",
-        help="Input format (default: auto from file extensions). Use rf3 for RosettaFold3 confidences JSON.",
+        help=(
+            "Input format (default: auto from file extensions, with af3 vs rf3 "
+            "decided by the summary_confidences contents). Use rf3 for "
+            "RosettaFold3 confidences JSON."
+        ),
     )
     parser.add_argument(
         "--update-summary",
@@ -131,42 +200,28 @@ def main():
 
     # pae_AURKA_TPX2_model_0.npz
 
-    if ".pdb" in pdb_path and pae_file_path.endswith(".npz"):
-        pdb_stem = pdb_path.replace(".pdb", "")
-        path_stem = f'{pdb_path.replace(".pdb", "")}_{pae_string}_{dist_string}'
-        af2 = False
-        af3 = False
-        boltz = True
-        cif = False
-    elif ".cif" in pdb_path and pae_file_path.endswith(".npz"):
-        pdb_stem = pdb_path.replace(".cif", "")
-        path_stem = f'{pdb_path.replace(".cif", "")}_{pae_string}_{dist_string}'
-        af2 = False
-        af3 = False
-        boltz = True
+    struct_name = os.path.basename(pdb_path)
+    out_dir = os.path.dirname(pdb_path)
+
+    if ".cif" in struct_name:
+        name_stem = struct_name.replace(".cif", "")
         cif = True
-    elif ".cif" in pdb_path and pae_file_path.endswith(".json"):
-        pdb_stem = pdb_path.replace(".cif", "")
-        path_stem = f'{pdb_path.replace(".cif", "")}_{pae_string}_{dist_string}'
-        af2 = False
-        af3 = True
-        boltz = False
-        cif = True
-    elif ".pdb" in pdb_path:
-        pdb_stem = pdb_path.replace(".pdb", "")
-        path_stem = f'{pdb_path.replace(".pdb", "")}_{pae_string}_{dist_string}'
-        af2 = True
-        af3 = False
-        boltz = False
+    elif ".pdb" in struct_name:
+        name_stem = struct_name.replace(".pdb", "")
         cif = False
     else:
         print("Wrong PDB or PAE file type ", pdb_path)
         sys.exit()
 
-    rf3 = args.format == "rf3" and af3
-    if args.format == "rf3" and ".cif" in pdb_path and pae_file_path.endswith(".json"):
-        af3 = True
-        rf3 = True
+    pdb_stem = os.path.join(out_dir, name_stem) if out_dir else name_stem
+    path_stem = f"{pdb_stem}_{pae_string}_{dist_string}"
+
+    # One flag per predictor; rf3 is a peer of af2/af3/boltz, not a mode of af3.
+    fmt = resolve_input_format(args.format, struct_name, pae_file_path)
+    af2 = fmt == "af2"
+    af3 = fmt == "af3"
+    boltz = fmt == "boltz"
+    rf3 = fmt == "rf3"
 
     file_path = path_stem + "_ipsae.tsv"
     file2_path = path_stem + "_ipsae_byres.tsv"
@@ -403,6 +458,7 @@ def main():
     residues = []
     cb_residues = []
     chains = []
+    atom_num_base = None  # lowest atom serial in the file; see CA_atom_num below
     atomsitefield_num = 0
     atomsitefield_dict = (
         {}
@@ -462,6 +518,9 @@ def main():
                     token_mask.append(0)
                     continue
 
+                if atom_num_base is None or atom["atom_num"] < atom_num_base:
+                    atom_num_base = atom["atom_num"]
+
                 if atom["atom_name"] == "CA" or "C1" in atom["atom_name"]:
                     token_mask.append(1)
                     residues.append(
@@ -502,12 +561,13 @@ def main():
 
     # Convert structure information to numpy arrays
     numres = len(residues)
-    CA_atom_num = np.array(
-        [res["atom_num"] - 1 for res in residues]
-    )  # for AF3 atom indexing from 0
-    CB_atom_num = np.array(
-        [res["atom_num"] - 1 for res in cb_residues]
-    )  # for AF3 atom indexing from 0
+    # Indices into the atom_plddts array, which is ordered as the file's atoms.
+    # AF3 numbers mmCIF atoms from 1 but RF3 numbers them from 0, so take the
+    # base from the file rather than assuming either.
+    if atom_num_base is None:
+        atom_num_base = 1
+    CA_atom_num = np.array([res["atom_num"] - atom_num_base for res in residues])
+    CB_atom_num = np.array([res["atom_num"] - atom_num_base for res in cb_residues])
     coordinates = np.array([res["coor"] for res in cb_residues])
     chains = np.array(chains)
     unique_chains = np.unique(chains)
@@ -539,7 +599,7 @@ def main():
         )
     )
 
-    # Load AF2, AF3, or BOLTZ1 data and extract plddt and pae_matrix (and ptm_matrix if available)
+    # Load AF2, AF3, RF3, or BOLTZ1 data and extract plddt and pae_matrix (and ptm_matrix if available)
     if af2:
 
         if os.path.exists(pae_file_path):
@@ -625,7 +685,9 @@ def main():
         else:
             print("Boltz1 summary file does not exist: ", summary_file_path)
 
-    if af3:
+    if af3 or rf3:
+        # RF3 writes AF3-shaped confidences, so the per-atom pLDDT / PAE parsing is
+        # shared; only the summary ipTM (below) and the pLDDT scale differ.
         # Example Alphafold3 server filenames
         #   fold_aurka_0_tpx2_0_full_data_0.json
         #   fold_aurka_0_tpx2_0_summary_confidences_0.json
@@ -634,16 +696,21 @@ def main():
         #   confidences.json
         #   summary_confidences.json
         #   model1.cif
+        # Example RF3 filenames
+        #   <id>_confidences.json
+        #   <id>_summary_confidences.json
+        #   <id>_model.cif
+        label = "RF3" if rf3 else "AF3"
         if os.path.exists(pae_file_path):
             with open(pae_file_path, "r") as file:
                 data = json.load(file)
         else:
-            print("AF3 PAE file does not exist: ", pae_file_path)
+            print(f"{label} PAE file does not exist: ", pae_file_path)
             sys.exit()
 
         atom_plddts = np.array(data["atom_plddts"])
         if rf3:
-            atom_plddts = atom_plddts * 100.0
+            atom_plddts = atom_plddts * 100.0  # RF3 reports pLDDT on 0-1, AF3 on 0-100
         plddt = atom_plddts[CA_atom_num]  # pull out residue plddts from Calpha atoms
         cb_plddt = atom_plddts[
             CB_atom_num
@@ -653,57 +720,53 @@ def main():
         # Modified residues have separate tokens for each atom, so need to pull out Calpha atom as token
         # Skip ligands
         if "pae" in data:
-            pae_matrix_af3 = np.array(data["pae"])
+            pae_matrix_full = np.array(data["pae"])
         else:
-            print("no PAE data in AF3 json file; quitting")
+            print(f"no PAE data in {label} json file; quitting")
             sys.exit()
 
-        # Set pae_matrix for AF3 from subset of full PAE matrix from json file
+        # Set pae_matrix from subset of full PAE matrix from json file
         token_array = np.array(token_mask)
-        pae_matrix = pae_matrix_af3[
+        pae_matrix = pae_matrix_full[
             np.ix_(token_array.astype(bool), token_array.astype(bool))
         ]
-        # Get iptm matrix from AF3 summary_confidences file
-        iptm_af3 = {
-            chain1: {chain2: 0 for chain2 in unique_chains if chain1 != chain2}
-            for chain1 in unique_chains
-        }
 
-        summary_file_path = None
-        if "confidences" in pae_file_path:
-            summary_file_path = pae_file_path.replace(
-                "confidences", "summary_confidences"
-            )
-        elif "full_data" in pae_file_path:
-            summary_file_path = pae_file_path.replace(
-                "full_data", "summary_confidences"
-            )
+        # Model ipTM from the summary_confidences file. AF3 provides a per-chain-pair
+        # matrix; RF3's ComputeIPTM scores all interchain token pairs at once, so it
+        # only writes one interface-wide scalar, applied to every pair as for AF2.
+        iptm_af3 = init_chainpairdict_zeros(unique_chains)
+        iptm_rf3 = -1.0
+        summary_file_path = summary_confidences_path(pae_file_path)
 
         if summary_file_path is not None and os.path.exists(summary_file_path):
             with open(summary_file_path, "r") as file:
                 data_summary = json.load(file)
-            af3_chain_pair_iptm_data = data_summary.get("chain_pair_iptm")
-            if af3_chain_pair_iptm_data is not None:
-                for chain1 in unique_chains:
-                    nchain1 = ord(chain1) - ord("A")  # map A,B,C... to 0,1,2...
-                    for chain2 in unique_chains:
-                        if chain1 == chain2:
-                            continue
-                        nchain2 = ord(chain2) - ord("A")
-                        if nchain1 < len(af3_chain_pair_iptm_data) and nchain2 < len(
-                            af3_chain_pair_iptm_data[nchain1]
-                        ):
-                            iptm_af3[chain1][chain2] = af3_chain_pair_iptm_data[
-                                nchain1
-                            ][nchain2]
-            elif rf3:
-                print(
-                    "Warning: RF3 summary has no chain_pair_iptm; ipTM from summary will be 0",
-                    file=sys.stderr,
-                )
+            if rf3:
+                iptm_value = data_summary.get("iptm")
+                iptm_rf3 = float(iptm_value) if iptm_value is not None else -1.0
+            else:
+                af3_chain_pair_iptm_data = data_summary.get("chain_pair_iptm")
+                if af3_chain_pair_iptm_data is None:
+                    print(
+                        "Warning: AF3 summary has no chain_pair_iptm; "
+                        "ipTM from summary will be 0",
+                        file=sys.stderr,
+                    )
+                else:
+                    for chain1 in unique_chains:
+                        nchain1 = ord(chain1) - ord("A")  # map A,B,C... to 0,1,2...
+                        for chain2 in unique_chains:
+                            if chain1 == chain2:
+                                continue
+                            nchain2 = ord(chain2) - ord("A")
+                            if nchain1 < len(
+                                af3_chain_pair_iptm_data
+                            ) and nchain2 < len(af3_chain_pair_iptm_data[nchain1]):
+                                iptm_af3[chain1][chain2] = af3_chain_pair_iptm_data[
+                                    nchain1
+                                ][nchain2]
         else:
-            if not rf3:
-                print("AF3 summary file does not exist: ", summary_file_path)
+            print(f"{label} summary file does not exist: ", summary_file_path)
 
     # Compute chain-pair-specific interchain PTM and PAE, count valid pairs, and count unique residues
     # First, create dictionaries of appropriate size: top keys are chain1 and chain2 where chain1 != chain2
@@ -1326,6 +1389,8 @@ def main():
                 iptm_af = iptm_af3[chain1][
                     chain2
                 ]  # symmetric value for each chain pair
+            if rf3:
+                iptm_af = iptm_rf3  # same for all chain pairs in entry
             if boltz:
                 iptm_af = iptm_boltz[chain1][chain2]
 
@@ -1482,7 +1547,7 @@ def main():
     PML.close()
     OUT2.close()
 
-    if getattr(args, "update_summary", None) and (af3 or boltz):
+    if getattr(args, "update_summary", None) and (af3 or rf3 or boltz):
         summary_path = args.update_summary
         binder_chain = getattr(args, "binder_chain", "A")
         target_chain = getattr(args, "target_chain", "B")

--- a/tests/bin/test_ipsae.py
+++ b/tests/bin/test_ipsae.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pytest", "numpy"]
+# ///
+
+"""Tests for bin/ipsae.py helpers (AF2 list-wrapped PAE JSON, Protenix key aliases)."""
+
+import importlib.util
+from pathlib import Path
+
+_MODPATH = Path(__file__).resolve().parents[2] / "bin" / "ipsae.py"
+_spec = importlib.util.spec_from_file_location("ipsae", _MODPATH)
+ipsae = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ipsae)
+
+
+def test_unwrap_af2_list_wrapped_pae():
+    inner = {"predicted_aligned_error": [[0.1, 0.2], [0.2, 0.1]]}
+    assert ipsae.unwrap_json_object([inner]) == inner
+    assert ipsae.unwrap_json_object(inner) is inner
+
+
+def test_normalize_protenix_full_data_keys():
+    raw = {"atom_plddt": [0.9, 0.8], "token_pair_pae": [[0.1, 1.0], [1.0, 0.1]]}
+    out = ipsae.normalize_token_pae_json(raw)
+    assert out["atom_plddts"] == [0.9, 0.8]
+    assert out["pae"] == [[0.1, 1.0], [1.0, 0.1]]
+    already = {"atom_plddts": [50.0], "pae": [[0.0]]}
+    assert ipsae.normalize_token_pae_json(already)["atom_plddts"] == [50.0]
+
+
+def test_summary_confidences_path_protenix(tmp_path):
+    pae = tmp_path / "cx_full_data_sample_0.json"
+    summary = tmp_path / "cx_summary_confidence_sample_0.json"
+    pae.write_text("{}")
+    summary.write_text("{}")
+    got = ipsae.summary_confidences_path(str(pae))
+    assert Path(got).name == "cx_summary_confidence_sample_0.json"


### PR DESCRIPTION
## Summary

- Treat RF3 as its own input format in `bin/ipsae.py` rather than a nested AF3 mode that expects `chain_pair_iptm` (Foundry RF3 writes a single scalar `iptm` plus chain-pair PAE/PDE matrices).
- Auto-detect RF3 vs AF3 in `--format auto` by inspecting the sibling `summary_confidences` JSON.
- Read RF3 model ipTM from the scalar `iptm` field (applied to every chain pair, as for AF2).
- Fix per-residue pLDDT indexing for RF3 mmCIF files, which number atoms from 0 (AF3 uses 1-based ids).
- Rewrite summary path lookup to touch only the basename so parent directories containing `confidences` are not mangled.

## Context

The RFD3 postprocess step (`bin/rfd3/postprocess_rf3_batch_outputs.py`) invokes `ipsae.py --format rf3`. Previously the script still looked for AF3's `chain_pair_iptm` matrix, logged a warning, and wrote `0.000` in the TSV `ipTM_af` column even though RF3's summary already contained a valid `iptm`. pDockQ / per-residue pLDDT were also wrong because RF3 atom ids start at 0.

## Test plan

- [x] Verified against Foundry RF3 regression fixture `5vht_from_file` (scalar ipTM 0.911 appears in TSV; `rf3_ipsae_*` written to summary)
- [ ] Run an RFD3 workflow example that hits `postprocess_rf3_batch_outputs.py` and confirm no `chain_pair_iptm` warning and sensible `ipTM_af` / pDockQ values in ipSAE TSVs