### PR TITLE
Fix ipSAE structure format detection to use the real file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BindCraft report accept summary: trajectory outcomes (Relaxed / LowConfidence / Clashing) now sum to total trajectories; Accepted / Rejected MPNN designs are shown separately.
 - BindCraft: process now fails (non-zero exit) when `bindcraft.py` crashes; previously `| tee bindcraft.log` masked the Python exit code so Nextflow marked the task COMPLETED.
 - `bin/ipsae.py` RF3 support: treat RF3 as its own input format (not a nested AF3 mode), read the scalar `iptm` from RF3 summary JSON instead of the AF3-only `chain_pair_iptm` matrix, auto-detect RF3 vs AF3 from summary contents, and index per-atom pLDDT correctly for RF3 mmCIF files (atoms numbered from 0).
+- `bin/ipsae.py`: detect the structure format from the real file extension rather than a substring match. The rfd3 workflow carries the RFdiffusion3 backbone filename into the design id, so Boltz writes files like `<design>_model_0.cif_b0_d1_model_0.pdb` — a PDB whose name contains `.cif`. Those were parsed as mmCIF, leaving `atomsitefield_dict` empty and failing with `KeyError: 'id'`.
 - `bin/ipsae.py`: unwrap list-wrapped native AF2 `pae_model_*.json` so ipSAE can read `predicted_aligned_error`.
 - `bin/ipsae.py`: accept Protenix full-data JSON (`token_pair_pae`, `atom_plddt`, `*_summary_confidence_sample_N.json`) and scale 0–1 pLDDT like RF3.
 

--- a/bin/ipsae.py
+++ b/bin/ipsae.py
@@ -136,6 +136,27 @@ def detect_cif_json_format(pae_file_path: str) -> str:
     return "af3"
 
 
+def split_structure_name(struct_name: str):
+    """Split a structure filename into (stem, is_mmcif) using its real extension.
+
+    Substring tests like ``".cif" in struct_name`` are not safe here, because a
+    filename may carry a structure extension in the middle of its name. The
+    nf-binder-design rfd3 workflow produces exactly that: RFdiffusion3 emits
+    backbones called ``<design>_model_0.cif``, the whole filename becomes the
+    downstream design id, and Boltz then writes
+    ``<design>_model_0.cif_b0_d1_model_0.pdb`` -- a PDB file whose name contains
+    ".cif". A substring test calls that mmCIF, so no "_atom_site." header lines
+    are ever parsed, ``atomsitefield_dict`` stays empty, and
+    ``parse_cif_atom_line`` dies with ``KeyError: 'id'``.
+
+    Returns None if the name has neither extension.
+    """
+    for ext, is_cif in ((".cif", True), (".pdb", False)):
+        if struct_name.endswith(ext):
+            return struct_name[: -len(ext)], is_cif
+    return None
+
+
 def resolve_input_format(input_format: str, struct_name: str, pae_file_path: str) -> str:
     """Resolve an explicit format request, or guess one from the input files."""
     if input_format not in ("auto",) + SUPPORTED_FORMATS:
@@ -148,10 +169,13 @@ def resolve_input_format(input_format: str, struct_name: str, pae_file_path: str
 
     if pae_file_path.endswith(".npz"):
         return "boltz"
-    if ".cif" in struct_name and pae_file_path.endswith(".json"):
-        return detect_cif_json_format(pae_file_path)
-    if ".pdb" in struct_name:
-        return "af2"
+    split = split_structure_name(struct_name)
+    if split is not None:
+        _, is_cif = split
+        if is_cif and pae_file_path.endswith(".json"):
+            return detect_cif_json_format(pae_file_path)
+        if not is_cif:
+            return "af2"
     raise ValueError(
         f"Cannot determine input format from structure {struct_name!r} "
         f"and PAE file {os.path.basename(pae_file_path)!r}"
@@ -240,15 +264,11 @@ def main():
     struct_name = os.path.basename(pdb_path)
     out_dir = os.path.dirname(pdb_path)
 
-    if ".cif" in struct_name:
-        name_stem = struct_name.replace(".cif", "")
-        cif = True
-    elif ".pdb" in struct_name:
-        name_stem = struct_name.replace(".pdb", "")
-        cif = False
-    else:
+    split = split_structure_name(struct_name)
+    if split is None:
         print("Wrong PDB or PAE file type ", pdb_path)
         sys.exit()
+    name_stem, cif = split
 
     pdb_stem = os.path.join(out_dir, name_stem) if out_dir else name_stem
     path_stem = f"{pdb_stem}_{pae_string}_{dist_string}"

--- a/tests/bin/test_ipsae.py
+++ b/tests/bin/test_ipsae.py
@@ -4,7 +4,8 @@
 # dependencies = ["pytest", "numpy"]
 # ///
 
-"""Tests for bin/ipsae.py helpers (AF2 list-wrapped PAE JSON, Protenix key aliases)."""
+"""Tests for bin/ipsae.py helpers (structure extension detection, AF2 list-wrapped
+PAE JSON, Protenix key aliases)."""
 
 import importlib.util
 from pathlib import Path
@@ -37,3 +38,24 @@ def test_summary_confidences_path_protenix(tmp_path):
     summary.write_text("{}")
     got = ipsae.summary_confidences_path(str(pae))
     assert Path(got).name == "cx_summary_confidence_sample_0.json"
+
+
+def test_split_structure_name_uses_real_extension():
+    assert ipsae.split_structure_name("model_0.cif") == ("model_0", True)
+    assert ipsae.split_structure_name("model_0.pdb") == ("model_0", False)
+    assert ipsae.split_structure_name("model_0.npz") is None
+
+
+def test_split_structure_name_ignores_embedded_extension():
+    # rfd3 -> Boltz names carry the RFdiffusion3 backbone filename, extension and
+    # all, in the middle of the design id. This must still read as a PDB.
+    name = "epea_tipfix_0_model_0.cif_b0_d1_model_0.pdb"
+    assert ipsae.split_structure_name(name) == (
+        "epea_tipfix_0_model_0.cif_b0_d1_model_0",
+        False,
+    )
+
+
+def test_resolve_input_format_embedded_cif_in_pdb_name():
+    name = "epea_tipfix_0_model_0.cif_b0_d1_model_0.pdb"
+    assert ipsae.resolve_input_format("auto", name, "whatever_pae.json") == "af2"


### PR DESCRIPTION
## Problem

`bin/ipsae.py` decided mmCIF vs PDB with substring tests:

```python
if ".cif" in struct_name:
    ...
elif ".pdb" in struct_name:
```

The `rfd3` workflow carries the whole RFdiffusion3 backbone filename into the downstream design id, so Boltz writes structures like:

```
epea_tipfix_0_model_0.cif_b0_d1_model_0.pdb
```

That is a **PDB** file whose *name* contains `.cif`. The substring test classified it as mmCIF, so no `_atom_site.` header lines were ever parsed, `atomsitefield_dict` stayed empty, and `parse_cif_atom_line` died with:

```
KeyError: 'id'
```

Hit while running `--method rfd3` with `--full_refold_with boltz`.

## Fix

Add `split_structure_name()`, which matches on the real extension and returns `(stem, is_mmcif)` or `None`, and use it at both sites that made this decision:

- `resolve_input_format()` — same substring flaw two lines apart, fixed at the same time
- `main()` — the site that actually raised

Behaviour is unchanged for filenames that genuinely end in their extension, so AF2/AF3/Boltz/Protenix inputs are unaffected.

This is complementary to #19, which fixed the *PAE* file format detection (`detect_cif_json_format`); the structure filename test was left alone there.

## Tests

Three cases added to `tests/bin/test_ipsae.py`, including the embedded-extension name above. `tests/bin/test_ipsae.py` passes (6 passed).