### PR TITLE
Pull rc-foundry as an OCI image, not an ORAS SIF artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BindCraft report accept summary: trajectory outcomes (Relaxed / LowConfidence / Clashing) now sum to total trajectories; Accepted / Rejected MPNN designs are shown separately.
 - BindCraft: process now fails (non-zero exit) when `bindcraft.py` crashes; previously `| tee bindcraft.log` masked the Python exit code so Nextflow marked the task COMPLETED.
 - `bin/ipsae.py` RF3 support: treat RF3 as its own input format (not a nested AF3 mode), read the scalar `iptm` from RF3 summary JSON instead of the AF3-only `chain_pair_iptm` matrix, auto-detect RF3 vs AF3 from summary contents, and index per-atom pLDDT correctly for RF3 mmCIF files (atoms numbered from 0).
+- rfd3 modules pull `rc-foundry:0.2.0-weights` as an ordinary container image instead of `oras://`. The image was rebuilt as a multi-layer OCI image, so an `oras://` pull now fails with `ORAS SIF image should have a single layer, found 20`.
 - `bin/ipsae.py`: unwrap list-wrapped native AF2 `pae_model_*.json` so ipSAE can read `predicted_aligned_error`.
 - `bin/ipsae.py`: accept Protenix full-data JSON (`token_pair_pae`, `atom_plddt`, `*_summary_confidence_sample_N.json`) and scale 0–1 pLDDT like RF3.
 

--- a/modules/local/rfd3/mpnn.nf
+++ b/modules/local/rfd3/mpnn.nf
@@ -1,5 +1,5 @@
 process MPNN {
-    container 'oras://ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights'
+    container 'ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights'
 
     publishDir path: "${params.outdir}/rfd3/mpnn", pattern: 'output/*.cif', mode: 'copy'
     publishDir path: "${params.outdir}/rfd3/mpnn", pattern: 'output/*.fa', mode: 'copy'

--- a/modules/local/rfd3/rfdiffusion3.nf
+++ b/modules/local/rfd3/rfdiffusion3.nf
@@ -1,5 +1,5 @@
 process RFDIFFUSION3 {
-    container 'oras://ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights'
+    container 'ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights'
 
     publishDir path: "${params.outdir}/rfd3/rfdiffusion3", pattern: 'output/*.cif.gz', mode: 'copy'
     publishDir path: "${params.outdir}/rfd3/rfdiffusion3", pattern: 'output/*.json', mode: 'copy'

--- a/modules/local/rfd3/rosettafold3.nf
+++ b/modules/local/rfd3/rosettafold3.nf
@@ -1,5 +1,5 @@
 process ROSETTAFOLD3 {
-    container 'oras://ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights'
+    container 'ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights'
 
     publishDir path: "${params.outdir}/rfd3/rosettafold3/output", pattern: 'output/*', mode: 'copy', saveAs: { it.replaceFirst('output/', '') }
 


### PR DESCRIPTION
## Problem

`rc-foundry:0.2.0-weights` has been rebuilt (2026-09-09) as an ordinary multi-layer OCI image:

```
mediaType: application/vnd.oci.image.index.v1+json
  └─ linux/amd64: 20 × application/vnd.oci.image.layer.v1.tar+gzip
  └─ attestation-manifest
```

It used to be published as a single-blob SIF artifact, which is why the three rfd3 modules request it as `oras://`. That scheme expects exactly one `application/vnd.sylabs.sif.layer.v1.sif` layer, so the pull now fails:

```
$ apptainer pull oras://ghcr.io/australian-protein-design-initiative/containers/rc-foundry:0.2.0-weights
FATAL:   While pulling image from oci registry: error fetching image to cache:
         failed to get checksum for oras://...: ORAS SIF image should have a single layer, found 20
```

This breaks `--method rfd3` for anyone without a warm cache.

## Fix

Drop the `oras://` prefix from `rfdiffusion3.nf`, `mpnn.nf` and `rosettafold3.nf`. These were the only three `oras://` declarations in the repo; every other container is already a bare registry path.

## Note for anyone with an existing cache

The tag is unchanged, and Nextflow's `SingularityCache` strips the protocol when naming the cached SIF — so `oras://…/rc-foundry:0.2.0-weights` and `…/rc-foundry:0.2.0-weights` both map to:

```
ghcr.io-australian-protein-design-initiative-containers-rc-foundry-0.2.0-weights.img
```

An existing cache entry is therefore reused silently after this change, and it will be the **old** image — which does not contain the HyperMPNN or PottsMPNN checkpoints added in the rebuild. Delete that `.img` from `NXF_SINGULARITY_CACHEDIR` to pick the new image up (and don't do it while a run is using it).