### PR TITLE
Stop docs deploys racing each other for the gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,14 @@ on:
       # Semver X.Y.Z without leading v (e.g. 0.2.0); glob + / picomatch, not regex
       - '[0-9]+.[0-9]+.[0-9]+'
 
+# main, develop and version tags all deploy to the same gh-pages branch, so their
+# runs must not overlap. The default per-ref group would not help here: the refs
+# differ, the branch they write to does not. cancel-in-progress is false so a
+# queued deploy waits its turn instead of being dropped.
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -44,22 +52,46 @@ jobs:
         run: |
           git fetch origin gh-pages --depth=1 || true
 
+          # mike commits to the local gh-pages branch and pushes it. If another
+          # docs run landed on gh-pages first, that push is rejected with
+          # "cannot lock ref 'refs/heads/gh-pages'". Resync the local branch to
+          # the remote tip and rebuild, rather than failing the release.
+          retry_gh_pages () {
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+              if [[ ${attempt} -eq 3 ]]; then
+                break
+              fi
+              echo "::warning::gh-pages deploy failed (attempt ${attempt}/3); resyncing and retrying: $*"
+              git fetch origin gh-pages --depth=1 || true
+              if git rev-parse --verify -q FETCH_HEAD >/dev/null; then
+                git branch -f gh-pages FETCH_HEAD || true
+              fi
+              sleep $(( attempt * 15 ))
+            done
+            echo "::error::gh-pages deploy failed after 3 attempts: $*"
+            return 1
+          }
+
           DOCS_BRANCHES=("develop" "develop-rfd3" "rfd3")
 
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
-            mike deploy --config-file docs/mkdocs.yml --push --update-aliases "${VERSION}"
+            retry_gh_pages mike deploy --config-file docs/mkdocs.yml --push --update-aliases "${VERSION}"
           elif [[ "${GITHUB_REF}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
-            mike deploy --config-file docs/mkdocs.yml --push --update-aliases "${VERSION}"
+            retry_gh_pages mike deploy --config-file docs/mkdocs.yml --push --update-aliases "${VERSION}"
           elif [[ "${GITHUB_REF}" == refs/heads/main ]]; then
-            mike deploy --config-file docs/mkdocs.yml --push --update-aliases main latest
-            mike set-default --config-file docs/mkdocs.yml --push latest
+            retry_gh_pages mike deploy --config-file docs/mkdocs.yml --push --update-aliases main latest
+            retry_gh_pages mike set-default --config-file docs/mkdocs.yml --push latest
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             BRANCH="${GITHUB_REF#refs/heads/}"
             for b in "${DOCS_BRANCHES[@]}"; do
               if [[ "${BRANCH}" == "${b}" ]]; then
-                mike deploy --config-file docs/mkdocs.yml --push --update-aliases "${BRANCH}"
+                retry_gh_pages mike deploy --config-file docs/mkdocs.yml --push --update-aliases "${BRANCH}"
                 break
               fi
             done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,11 @@ Steps:
 `main` and `develop` are kept at the same commit for a release -- fast-forward `main` to
 `develop` rather than merging, so the tag is reachable from both.
 
+A release push fires the `docs` workflow up to three times (`main`, `develop`, the tag).
+They all deploy to the same `gh-pages` branch, so they are serialised by a `docs-deploy`
+concurrency group and retry a rejected push; let them finish before assuming the
+versioned docs are live.
+
 
 ## Python
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- docs workflow: `main`, `develop` and tag pushes no longer race each other deploying to `gh-pages`. A release triggered all three at once and two failed with `cannot lock ref 'refs/heads/gh-pages'`, so the versioned docs were never published. Runs are now serialised and a rejected push is retried.
+
 ## [0.3.1] - 2026-09-09
 
 ### Added

--- a/docs/docs/extra/development.md
+++ b/docs/docs/extra/development.md
@@ -104,6 +104,11 @@ in the repository is unprefixed (`0.3.0`, `0.2.0`, ...). Pushing the tag is what
 publishes the immutable `/X.Y.Z/` docs; pushes to `main` and `develop` update the
 floating docs for those branches.
 
+Steps 4 and 5 above trigger the `docs` workflow up to three times at once, and each run
+deploys to the same `gh-pages` branch. A `docs-deploy` concurrency group serialises them
+and a rejected push is retried, so they queue rather than clobber each other -- but they
+run one at a time, so give them a few minutes before checking that `/X.Y.Z/` is live.
+
 
 ## License
 


### PR DESCRIPTION
## Problem

Releasing version 0.3.1 pushed `main`, `develop` and the tag within about five seconds. That fired the `docs` workflow three times, and all three runs do `mike deploy --push` against the **same** `gh-pages` branch:

```
! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages':
  is at a7824c0d... but expected 988498f1...)
```

`main` won the lock; the tag and `develop` runs failed. The practical consequence is that the `0.3.1` versioned docs were **never published** — `gh-pages` had no `0.3.1/` tree and it was absent from `versions.json`.

## Fix

**1. A single `docs-deploy` concurrency group.** with `cancel-in-progress: false` so a queued deploy waits its turn instead of being dropped.

**2. Retry a rejected push.** GitHub keeps only one *pending* run per concurrency group — a third trigger cancels the queued one — so a collision is still possible even with (1). `retry_gh_pages` wraps every pushing `mike` call, resyncing the local `gh-pages` to the remote tip between attempts, and fails the step after 3 rather than passing silently.

The two compose: the concurrency group makes collisions rare, the retry handles the residual case.

## Verification

- `docs.yml` parses as YAML, and the embedded `Deploy docs` script passes `bash -n`.
- `retry_gh_pages` exercised with a stubbed `mike`: returns 0 when a later attempt succeeds, and returns 1 with an `::error::` annotation when all three fail (so a genuine breakage still goes red).
- (the failing tag build was re-run manually so `0.3.1` docs are now on `gh-pages` and in `versions.json`).