### PR TITLE
Batch Boltz refold predictions with --boltz_refold_batch_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--method fold`: multi-method structure folding (AF2, Boltz-2, RosettaFold3, Protenix) with shared MSAs, MSA subsampling, and EnGens clustering (replaces the standalone `fold.nf` entrypoint). Also `engens.nf` for clustering an existing `.cif`/`.pdb` folder or glob.
 - `--method fold_pulldown`: multi-model target × binder pulldown (AF2/Boltz/RF3/Protenix) with per-structure and aggregate scores plus a Quarto report.
+- `--boltz_refold_batch_size`: designs per Boltz refold task, for both complex and binder-monomer refolding. Boltz pays a large fixed cost per invocation (Python and torch startup plus loading the checkpoints) that a one-design-per-task pipeline pays again for every design; passing a directory of YAMLs to a single `boltz predict` amortises it. Measured on a GB10 with Boltz-2 v2.2.1, 8 designs took 476.8 s as 8 invocations against 121.5 s as one (59.6 s against 15.2 s per design). Defaults to 1, which is the previous behaviour exactly; the trade-off in raising it is that a failed task loses every design in its batch. Named to stay distinct from the pre-existing `--boltz_batch_size`, which is `--diffusion_samples` per Boltz job in the `fold` workflows.
 - GPU provenance trace. Every GPU task now records the device it ran on to `<outdir>/logs/gpu_trace_<datestamp>.txt`: timestamp, task hash, process, hostname, `n_gpus`, and the GPU index, UUID, model, driver version and total memory. New parameters: `--gpu_trace_dir`, `--gpu_trace_file`.
 
 ### Changed

--- a/modules/local/common/boltz_compare_binder_monomer.nf
+++ b/modules/local/common/boltz_compare_binder_monomer.nf
@@ -1,27 +1,39 @@
 process BOLTZ_COMPARE_BINDER_MONOMER {
-    tag "${meta.id}"
+    // Batched tasks are tagged by their first design plus a count, so the trace stays
+    // readable and a task is still identifiable when a whole batch fails.
+    tag { (metas instanceof List && metas.size() > 1) ? "${metas.first().id} +${metas.size() - 1}" : "${(metas instanceof List ? metas.first() : metas).id}" }
     container 'ghcr.io/australian-protein-design-initiative/containers/boltz:v2.2.1-2'
     publishDir "${params.outdir}/boltz_refold/predict/binder_monomer", pattern: 'boltz_results_*', mode: 'copy'
     publishDir "${params.outdir}/boltz_refold/rmsd/aligned_rmsd_monomer_vs_af2ig", pattern: 'aligned_rmsd_monomer_vs_af2ig/*.pdb', mode: 'copy', saveAs: { file(it).name }
     publishDir "${params.outdir}/boltz_refold/rmsd/aligned_rmsd_monomer_vs_complex", pattern: 'aligned_rmsd_monomer_vs_complex/*.pdb', mode: 'copy', saveAs: { file(it).name }
 
     input:
-    tuple val(meta), path(af2ig_pdb), path(boltz_complex_pdb)
+    // Numbered staging for the same reason as BOLTZ_COMPARE_COMPLEX: a Nextflow collection
+    // will not stage two files sharing a basename, and RFD3 hands every design's RF3 output
+    // over as `model.cif`. Order is preserved, which is what pairs each staged file with its
+    // meta below. Design extensions come alongside, since the wildcard discards them; the
+    // Boltz complex outputs are always .pdb.
+    tuple val(metas), path(af2ig_pdbs, stageAs: 'design_inputs/input*'), path(boltz_complex_pdbs, stageAs: 'complex_inputs/complex*.pdb'), val(design_exts)
     val binder_chain
 
     output:
-    path ("boltz_results_${meta.id}_monomer"), emit: results
-    tuple val(meta), path("boltz_results_${meta.id}_monomer/predictions/${meta.id}_monomer/${meta.id}_monomer_model_0.pdb"), emit: pdb
-    tuple val(meta), path("confidence_monomer_${meta.id}.tsv"), emit: confidence_tsv
-    tuple val(meta), path("rmsd_monomer_vs_af2ig_${meta.id}.tsv"), emit: rmsd_monomer_vs_af2ig
-    tuple val(meta), path("rmsd_monomer_vs_complex_${meta.id}.tsv"), emit: rmsd_monomer_vs_complex
+    path ("boltz_results_*"), emit: results
+    tuple val(metas), path('per_design'), emit: per_design_bundle
     path ("aligned_rmsd_monomer_vs_af2ig/*.pdb"), emit: aligned_pdbs_monomer_vs_af2ig, optional: true
     path ("aligned_rmsd_monomer_vs_complex/*.pdb"), emit: aligned_pdbs_monomer_vs_complex, optional: true
 
     script:
-    def design_id = meta.id
-    def binder_id = "${design_id}_binder_monomer"
-    def yaml_file = "${design_id}_monomer.yml"
+    def metaList = metas instanceof List ? metas : [metas]
+    def designList = af2ig_pdbs instanceof List ? af2ig_pdbs : [af2ig_pdbs]
+    def complexList = boltz_complex_pdbs instanceof List ? boltz_complex_pdbs : [boltz_complex_pdbs]
+
+    // One line per design, consumed by the shell loops below. Built here rather than as a
+    // generated block of shell so the script length does not grow with the batch size.
+    def extList = design_exts instanceof List ? design_exts : [design_exts]
+    def manifest = [metaList, designList, complexList, extList]
+        .transpose()
+        .collect { m, d, c, e -> "${m.id}\t${d}\t${c}\t${e}" }
+        .join('\n')
 
     def output_transformed_flag = params.output_rmsd_aligned ? "--output-transformed aligned_rmsd_monomer_vs_af2ig/" : ''
     def output_transformed_flag_complex = params.output_rmsd_aligned ? "--output-transformed aligned_rmsd_monomer_vs_complex/" : ''
@@ -57,16 +69,34 @@ process BOLTZ_COMPARE_BINDER_MONOMER {
     # Prevent Python from using ~/.local/lib/ packages mounted inside the container
     export PYTHONNOUSERSITE=1
 
-    # Step 1: Create Boltz YAML for binder monomer only
-    # (no target specified = monomer mode)
-    /usr/bin/python3 ${projectDir}/bin/create_boltz_yaml.py \\
-        --binder_id '${binder_id}' \\
-        --binder_from_pdb '${af2ig_pdb}' \\
-        --binder_chains '${binder_chain}' \\
-        --binder_msa empty \\
-        --output_yaml '${yaml_file}'
+    cat > .batch_manifest.tsv <<'NFBD_MANIFEST_EOF'
+${manifest}
+NFBD_MANIFEST_EOF
 
-    # Step 2: Run Boltz prediction; fail if log shows GPU OOM batch skip (boltz may still exit 0)
+    # Step 1: Create one Boltz YAML per design for binder monomer only
+    # (no target specified = monomer mode), all into a single input directory
+    # Give every staged design its id and real extension back; tools downstream dispatch
+    # on the extension and rmsd4all needs a per-design unique basename.
+    mkdir -p boltz_inputs staged
+    while IFS=\$'\\t' read -r design_id staged_design complex_pdb design_ext; do
+        [[ -n "\$design_id" ]] || continue
+        ln -s "\$(readlink -f "\$staged_design")" "staged/\${design_id}.\${design_ext}"
+    done < .batch_manifest.tsv
+
+    while IFS=\$'\\t' read -r design_id staged_design complex_pdb design_ext; do
+        [[ -n "\$design_id" ]] || continue
+        design_pdb="staged/\${design_id}.\${design_ext}"
+        /usr/bin/python3 ${projectDir}/bin/create_boltz_yaml.py \\
+            --binder_id "\${design_id}_binder_monomer" \\
+            --binder_from_pdb "\$design_pdb" \\
+            --binder_chains '${binder_chain}' \\
+            --binder_msa empty \\
+            --output_yaml "boltz_inputs/\${design_id}_monomer.yml"
+    done < .batch_manifest.tsv
+
+    # Step 2: Run Boltz prediction once for the whole batch; fail if log shows GPU OOM batch
+    # skip (boltz may still exit 0). Passing the directory rather than a single YAML is what
+    # amortises model load and process startup over every design in the batch.
     BOLTZ_PREDICT_LOG=.boltz_predict_console.log
     rm -f "\$BOLTZ_PREDICT_LOG"
     set +e
@@ -75,7 +105,8 @@ process BOLTZ_COMPARE_BINDER_MONOMER {
         --preprocessing-threads ${task.cpus} \\
         --num_workers ${task.cpus} \\
         --output_format pdb \\
-        ${yaml_file} 2>&1 | tee "\$BOLTZ_PREDICT_LOG"
+        --out_dir boltz_batch \\
+        boltz_inputs 2>&1 | tee "\$BOLTZ_PREDICT_LOG"
     boltz_rc=\${PIPESTATUS[0]}
     set -e
     if grep -qF 'ran out of memory, skipping batch' "\$BOLTZ_PREDICT_LOG"; then
@@ -86,55 +117,87 @@ process BOLTZ_COMPARE_BINDER_MONOMER {
         exit "\$boltz_rc"
     fi
 
-    # Step 3: Run RMSD calculations
-    # Create directories for rmsd4all
-    mkdir -p fixed/
-    mkdir -p mobile/
+    # Boltz writes a batch to boltz_batch/boltz_results_boltz_inputs/predictions/<design_id>_monomer/.
+    # Reshape that into the per-design boltz_results_<design_id>_monomer/ layout this module has
+    # always emitted, so publishDir patterns and every downstream path are unchanged whatever
+    # the batch size is.
+    mkdir -p per_design
+    while IFS=\$'\\t' read -r design_id staged_design complex_pdb design_ext; do
+        [[ -n "\$design_id" ]] || continue
+        design_pdb="staged/\${design_id}.\${design_ext}"
 
-    # Get the monomer PDB path
-    MONOMER_PDB="boltz_results_${meta.id}_monomer/predictions/${meta.id}_monomer/${meta.id}_monomer_model_0.pdb"
+        src="boltz_batch/boltz_results_boltz_inputs/predictions/\${design_id}_monomer"
+        if [[ ! -d "\$src" ]]; then
+            echo "BOLTZ_COMPARE_BINDER_MONOMER: Boltz produced no prediction for '\${design_id}'." >&2
+            exit 1
+        fi
+        results_dir="boltz_results_\${design_id}_monomer"
+        mkdir -p "\${results_dir}/predictions"
+        mv "\$src" "\${results_dir}/predictions/\${design_id}_monomer"
 
-    # Run RMSD: monomer vs AF2IG binder (chain A)
-    # Create fresh directories for this comparison
-    rm -rf fixed/ mobile/
-    mkdir -p fixed/
-    mkdir -p mobile/
-    
-    ln -s "\$(readlink -f ${af2ig_pdb})" "fixed/\$(basename ${af2ig_pdb})"
-    ln -s "\$(readlink -f \$MONOMER_PDB)" "mobile/\$(basename \$MONOMER_PDB)"
+        # msa/, processed/ and lightning_logs/ describe the whole batch rather than one design,
+        # and this module has always published them inside boltz_results_<design_id>_monomer.
+        # Hard-linked, so there are no duplicated bytes and at the default batch size of 1 the
+        # published tree is exactly what it was before batching.
+        for aux in msa processed lightning_logs; do
+            aux_src="boltz_batch/boltz_results_boltz_inputs/\${aux}"
+            [[ -d "\$aux_src" ]] && cp -al "\$aux_src" "\${results_dir}/\${aux}"
+        done
 
-    # Monomer Boltz output uses chain A (create_boltz_yaml binder-only mode). AF2IG/RFD3 binder is ${binder_chain}.
-    /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
-        --tm-score \\
-        --superimpose-chains ${binder_chain} \\
-        --mobile-superimpose-chains A \\
-        --score-chains ${binder_chain} \\
-        --mobile-score-chains A \\
-        ${output_transformed_flag} \\
-        fixed/ mobile/ > rmsd_monomer_vs_af2ig_${meta.id}.tsv
+        MONOMER_PDB="\${results_dir}/predictions/\${design_id}_monomer/\${design_id}_monomer_model_0.pdb"
 
-    # Run RMSD: monomer vs Boltz complex binder (Boltz complex always labels binder chain A; see boltz_compare_complex.nf)
-    # Create fresh directories for this comparison
-    rm -rf fixed/ mobile/
-    mkdir -p fixed/
-    mkdir -p mobile/
-    
-    ln -s "\$(readlink -f ${boltz_complex_pdb})" "fixed/\$(basename ${boltz_complex_pdb})"
-    ln -s "\$(readlink -f \$MONOMER_PDB)" "mobile/\$(basename \$MONOMER_PDB)"
+        # Step 3: Run RMSD calculations
+        # Run RMSD: monomer vs AF2IG binder (chain A)
+        rm -rf fixed mobile
+        mkdir -p fixed mobile
 
-    /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
-        --tm-score \\
-        --superimpose-chains A \\
-        --mobile-superimpose-chains A \\
-        --score-chains A \\
-        --mobile-score-chains A \\
-        ${output_transformed_flag_complex} \\
-        fixed/ mobile/ > rmsd_monomer_vs_complex_${meta.id}.tsv
+        ln -s "\$(readlink -f "\$design_pdb")" "fixed/\$(basename "\$design_pdb")"
+        ln -s "\$(readlink -f "\$MONOMER_PDB")" "mobile/\$(basename "\$MONOMER_PDB")"
 
-    # Step 4: Parse confidence JSON
-    /usr/bin/python3 ${projectDir}/bin/parse_boltz_confidence.py \\
-        --json "boltz_results_${meta.id}_monomer/predictions/${meta.id}_monomer/confidence_${meta.id}_monomer_model_0.json" \\
-        --id "${meta.id}_monomer" \\
-        --binder "${binder_id}" > confidence_monomer_${meta.id}.tsv
+        # Monomer Boltz output uses chain A (create_boltz_yaml binder-only mode). AF2IG/RFD3 binder is ${binder_chain}.
+        /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
+            --tm-score \\
+            --superimpose-chains ${binder_chain} \\
+            --mobile-superimpose-chains A \\
+            --score-chains ${binder_chain} \\
+            --mobile-score-chains A \\
+            ${output_transformed_flag} \\
+            fixed/ mobile/ > "rmsd_monomer_vs_af2ig_\${design_id}.tsv"
+
+        # Run RMSD: monomer vs Boltz complex binder (Boltz complex always labels binder chain A; see boltz_compare_complex.nf)
+        rm -rf fixed mobile
+        mkdir -p fixed mobile
+
+        ln -s "\$(readlink -f "\$complex_pdb")" "fixed/\$(basename "\$complex_pdb")"
+        ln -s "\$(readlink -f "\$MONOMER_PDB")" "mobile/\$(basename "\$MONOMER_PDB")"
+
+        /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
+            --tm-score \\
+            --superimpose-chains A \\
+            --mobile-superimpose-chains A \\
+            --score-chains A \\
+            --mobile-score-chains A \\
+            ${output_transformed_flag_complex} \\
+            fixed/ mobile/ > "rmsd_monomer_vs_complex_\${design_id}.tsv"
+
+        # Step 4: Parse confidence JSON
+        /usr/bin/python3 ${projectDir}/bin/parse_boltz_confidence.py \\
+            --json "\${results_dir}/predictions/\${design_id}_monomer/confidence_\${design_id}_monomer_model_0.json" \\
+            --id "\${design_id}_monomer" \\
+            --binder "\${design_id}_binder_monomer" > "confidence_monomer_\${design_id}.tsv"
+
+        # Per-design bundle. The workflow re-associates these with their meta by design id,
+        # which is what keeps batched outputs correctly paired (see BOLTZ_REFOLD_CORE).
+        # Hard links rather than copies: same filesystem, no duplicated bytes, and unlike
+        # symlinks they stay valid wherever Nextflow stages the bundle.
+        d="per_design/\${design_id}"
+        mkdir -p "\$d"
+        ln "\$MONOMER_PDB" "\$d/\${design_id}_monomer.pdb"
+        ln "confidence_monomer_\${design_id}.tsv" "\$d/confidence.tsv"
+        ln "rmsd_monomer_vs_af2ig_\${design_id}.tsv" "\$d/rmsd_monomer_vs_af2ig.tsv"
+        ln "rmsd_monomer_vs_complex_\${design_id}.tsv" "\$d/rmsd_monomer_vs_complex.tsv"
+    done < .batch_manifest.tsv
+
+    rm -rf fixed mobile boltz_batch staged
     """
 }

--- a/modules/local/common/boltz_compare_complex.nf
+++ b/modules/local/common/boltz_compare_complex.nf
@@ -1,12 +1,19 @@
 process BOLTZ_COMPARE_COMPLEX {
-    tag "${meta.id}"
+    // Batched tasks are tagged by their first design plus a count, so the trace stays
+    // readable and a task is still identifiable when a whole batch fails.
+    tag { (metas instanceof List && metas.size() > 1) ? "${metas.first().id} +${metas.size() - 1}" : "${(metas instanceof List ? metas.first() : metas).id}" }
     container 'ghcr.io/australian-protein-design-initiative/containers/boltz:v2.2.1-2'
     publishDir "${params.outdir}/boltz_refold/predict/complex", pattern: 'boltz_results_*', mode: 'copy'
     publishDir "${params.outdir}/boltz_refold/rmsd/aligned_rmsd_target_aligned_binder", pattern: 'aligned_rmsd_target_aligned_binder/*.pdb', mode: 'copy', saveAs: { file(it).name }
     publishDir "${params.outdir}/boltz_refold/rmsd/aligned_rmsd_complex", pattern: 'aligned_rmsd_complex/*.pdb', mode: 'copy', saveAs: { file(it).name }
 
     input:
-    tuple val(meta), path(pdb)
+    // Staged as design_inputs/input1, input2, ... rather than under their own names:
+    // a Nextflow collection will not stage two files with the same basename, and RFD3
+    // hands every design's RF3 output over as `model.cif`. The numbered wildcard keeps
+    // input order, which is what pairs each staged file with its meta below. The real
+    // extensions come alongside in pdb_exts, since the wildcard discards them.
+    tuple val(metas), path(pdbs, stageAs: 'design_inputs/input*'), val(pdb_exts)
     val binder_chain
     val target_chain
     val create_target_msa
@@ -17,25 +24,23 @@ process BOLTZ_COMPARE_COMPLEX {
     path refold_target_fasta
 
     output:
-    path ("boltz_results_${meta.id}"), emit: results
-    tuple val(meta), path("boltz_results_${meta.id}/predictions/${meta.id}/${meta.id}_model_0.pdb"), emit: pdb
-    tuple val(meta), path("rmsd_target_aligned_binder_${meta.id}.tsv"), emit: rmsd_target_aligned
-    tuple val(meta), path("rmsd_complex_${meta.id}.tsv"), emit: rmsd_complex
+    path ("boltz_results_*"), emit: results
+    tuple val(metas), path('per_design'), emit: per_design_bundle
     path ("aligned_rmsd_target_aligned_binder/*.pdb"), emit: aligned_pdbs_target_aligned_binder, optional: true
     path ("aligned_rmsd_complex/*.pdb"), emit: aligned_pdbs_complex, optional: true
-    tuple val(meta), path("confidence_${meta.id}.tsv"), emit: confidence_tsv
-    tuple val(meta), path("boltz_results_${meta.id}/predictions/${meta.id}/*_ipsae.tsv"), emit: ipsae_tsv
-    tuple val(meta), path("boltz_results_${meta.id}/predictions/${meta.id}/*_ipsae_byres.tsv"), emit: ipsae_byres_tsv
 
     script:
-    def design_id = meta.id
-    def target_id = "${design_id}_target"
-    def binder_id = "${design_id}_binder"
-    def yaml_file = "${design_id}.yml"
-    // Stage the fixed structure under a design-id-aware basename so the rmsd4all `structure1`
-    // column is unique per-design (RFD3 stages every per-design RF3 output as `model.cif`,
-    // which collapses all rows to the same key and breaks downstream merges by structure1).
-    def fixed_pdb_name = "${design_id}.${pdb.extension}"
+    def metaList = metas instanceof List ? metas : [metas]
+    def pdbList = pdbs instanceof List ? pdbs : [pdbs]
+
+    // One line per design, consumed by the shell loops below. Built here rather
+    // than as a generated block of shell so the script length does not grow with
+    // the batch size.
+    def extList = pdb_exts instanceof List ? pdb_exts : [pdb_exts]
+    def manifest = [metaList, pdbList, extList]
+        .transpose()
+        .collect { m, p, e -> "${m.id}\t${p}\t${e}" }
+        .join('\n')
 
     def use_msa_server_flag = use_msa_server ? '--use_msa_server' : ''
     def templates_flag = templates ? "--templates '${templates}'" : ''
@@ -60,13 +65,15 @@ process BOLTZ_COMPARE_COMPLEX {
         binder_msa_flag = '--target_msa empty'
     }
 
-    // Target sequence for YAML "binder" slot (Boltz output chain B); see create_boltz_yaml.py protein ids A/B
+    // Target sequence for YAML "binder" slot (Boltz output chain B); see create_boltz_yaml.py protein ids A/B.
+    // When the target comes from the design structure it differs per design, so it is read from the
+    // loop variable rather than interpolated here.
     def target_source_args = ''
     if (refold_target_fasta.name != 'empty') {
         target_source_args = "--binder_from_fasta '${refold_target_fasta}' --binder_chains '${target_chain}'"
     }
     else {
-        target_source_args = "--binder_from_pdb '${pdb}' --binder_chains '${target_chain}'"
+        target_source_args = "--binder_from_pdb \"\$pdb_path\" --binder_chains '${target_chain}'"
     }
 
     """
@@ -99,20 +106,40 @@ process BOLTZ_COMPARE_COMPLEX {
     # Prevent Python from using ~/.local/lib/ packages mounted inside the container
     export PYTHONNOUSERSITE=1
 
-    # Create Boltz YAML from PDB: binder sequence goes to YAML target slot (Boltz chain A), target sequence to YAML binder slot (Boltz chain B)
-    /usr/bin/python3 ${projectDir}/bin/create_boltz_yaml.py \\
-        --target_id '${binder_id}' \\
-        --binder_id '${target_id}' \\
-        --target_from_pdb '${pdb}' \\
-        --target_chains '${binder_chain}' \\
-        ${target_source_args} \\
-        ${binder_msa_flag} \\
-        ${target_msa_flag} \\
-        --output_yaml '${yaml_file}' \\
-        ${use_msa_server_flag} \\
-        ${templates_flag}
+    cat > .batch_manifest.tsv <<'NFBD_MANIFEST_EOF'
+${manifest}
+NFBD_MANIFEST_EOF
 
-    # Run Boltz prediction; fail if log shows GPU OOM batch skip (boltz may still exit 0)
+    # Create one Boltz YAML per design, all into a single input directory: binder sequence
+    # goes to YAML target slot (Boltz chain A), target sequence to YAML binder slot (Boltz chain B)
+    # Give every staged input its design id and real extension back. Tools downstream
+    # dispatch on the extension, and rmsd4all needs a basename unique per design so its
+    # `structure1` column does not collapse to one key across the batch.
+    mkdir -p boltz_inputs staged
+    while IFS=\$'\\t' read -r design_id staged_path pdb_ext; do
+        [[ -n "\$design_id" ]] || continue
+        ln -s "\$(readlink -f "\$staged_path")" "staged/\${design_id}.\${pdb_ext}"
+    done < .batch_manifest.tsv
+
+    while IFS=\$'\\t' read -r design_id staged_path pdb_ext; do
+        [[ -n "\$design_id" ]] || continue
+        pdb_path="staged/\${design_id}.\${pdb_ext}"
+        /usr/bin/python3 ${projectDir}/bin/create_boltz_yaml.py \\
+            --target_id "\${design_id}_binder" \\
+            --binder_id "\${design_id}_target" \\
+            --target_from_pdb "\$pdb_path" \\
+            --target_chains '${binder_chain}' \\
+            ${target_source_args} \\
+            ${binder_msa_flag} \\
+            ${target_msa_flag} \\
+            --output_yaml "boltz_inputs/\${design_id}.yml" \\
+            ${use_msa_server_flag} \\
+            ${templates_flag}
+    done < .batch_manifest.tsv
+
+    # Run Boltz prediction once for the whole batch; fail if log shows GPU OOM batch skip
+    # (boltz may still exit 0). Passing the directory rather than a single YAML is what
+    # amortises model load and process startup over every design in the batch.
     BOLTZ_PREDICT_LOG=.boltz_predict_console.log
     rm -f "\$BOLTZ_PREDICT_LOG"
     set +e
@@ -122,7 +149,8 @@ process BOLTZ_COMPARE_COMPLEX {
         --num_workers ${task.cpus} \\
         --output_format pdb \\
         ${use_msa_server_flag} \\
-        ${yaml_file} 2>&1 | tee "\$BOLTZ_PREDICT_LOG"
+        --out_dir boltz_batch \\
+        boltz_inputs 2>&1 | tee "\$BOLTZ_PREDICT_LOG"
     boltz_rc=\${PIPESTATUS[0]}
     set -e
     if grep -qF 'ran out of memory, skipping batch' "\$BOLTZ_PREDICT_LOG"; then
@@ -133,55 +161,106 @@ process BOLTZ_COMPARE_COMPLEX {
         exit "\$boltz_rc"
     fi
 
-    # Run RMSD calculations
-    # Create directories for rmsd4all
-    mkdir -p fixed/
-    mkdir -p mobile/
+    # Boltz writes a batch to boltz_batch/boltz_results_boltz_inputs/predictions/<design_id>/.
+    # Reshape that into the per-design boltz_results_<design_id>/predictions/<design_id>/ layout
+    # this module has always emitted, so publishDir patterns and every downstream path are
+    # unchanged whatever the batch size is.
+    mkdir -p per_design
+    while IFS=\$'\\t' read -r design_id staged_path pdb_ext; do
+        [[ -n "\$design_id" ]] || continue
+        pdb_path="staged/\${design_id}.\${pdb_ext}"
 
-    # Symlink PDBs into directories
-    ln -s "\$(readlink -f ${pdb})" "fixed/${fixed_pdb_name}"
-    ln -s "\$(readlink -f boltz_results_${meta.id}/predictions/${meta.id}/${meta.id}_model_0.pdb)" "mobile/\$(basename boltz_results_${meta.id}/predictions/${meta.id}/${meta.id}_model_0.pdb)"
+        src="boltz_batch/boltz_results_boltz_inputs/predictions/\${design_id}"
+        if [[ ! -d "\$src" ]]; then
+            echo "BOLTZ_COMPARE_COMPLEX: Boltz produced no prediction for '\${design_id}'." >&2
+            exit 1
+        fi
+        mkdir -p "boltz_results_\${design_id}/predictions"
+        mv "\$src" "boltz_results_\${design_id}/predictions/\${design_id}"
 
-    # Boltz complex PDB chain IDs are always A,B from create_boltz_yaml.py: YAML "target" slot is
-    # chain A (here: input binder sequence), YAML "binder" slot is chain B (input target sequence).
-    # Input design structure keeps original chain IDs (${target_chain}=target, ${binder_chain}=binder).
-    # Mobile must use A=binder and B=target, not the input chain letters.
-    # Target-aligned binder RMSD: superimpose on target, score binder
-    /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
-        --tm-score \\
-        --superimpose-chains ${target_chain} \\
-        --mobile-superimpose-chains B \\
-        --score-chains ${binder_chain} \\
-        --mobile-score-chains A \\
-        ${output_transformed_flag_target} \\
-        fixed/ mobile/ > rmsd_target_aligned_binder_${meta.id}.tsv
+        # Boltz also writes msa/, processed/ and lightning_logs/ alongside predictions/, and
+        # this module has always published them inside boltz_results_<design_id>. They describe
+        # the whole batch rather than one design, so they are hard-linked into each design's
+        # results directory: no duplicated bytes, and at the default batch size of 1 the
+        # published tree is exactly what it was before batching.
+        for aux in msa processed lightning_logs; do
+            aux_src="boltz_batch/boltz_results_boltz_inputs/\${aux}"
+            [[ -d "\$aux_src" ]] && cp -al "\$aux_src" "boltz_results_\${design_id}/\${aux}"
+        done
 
-    # Complex RMSD: Boltz mobile is A=binder, B=target. Fixed side keeps input chain IDs; when those
-    # match Boltz (e.g. rfd AF2ig A=binder B=target), order aligns. Otherwise sequence-based alignment
-    # still pairs homologous chains; target-aligned row above is the robust pose metric.
-    /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
-        --tm-score \\
-        --superimpose-chains ${binder_chain},${target_chain} \\
-        --mobile-superimpose-chains A,B \\
-        --score-chains ${binder_chain},${target_chain} \\
-        --mobile-score-chains A,B \\
-        ${output_transformed_flag_complex} \\
-        fixed/ mobile/ > rmsd_complex_${meta.id}.tsv
+        pred_dir="boltz_results_\${design_id}/predictions/\${design_id}"
+        model_pdb="\${pred_dir}/\${design_id}_model_0.pdb"
 
-    /usr/bin/python3 ${projectDir}/bin/ipsae.py \\
-        --update-summary "boltz_results_${meta.id}/predictions/${meta.id}/confidence_${meta.id}_model_0.json" \\
-        --binder-chain A \\
-        --target-chain B \\
-        --format boltz \\
-        boltz_results_${meta.id}/predictions/${meta.id}/pae*.npz \\
-        boltz_results_${meta.id}/predictions/${meta.id}/*.pdb \\
-        10 10
+        # Run RMSD calculations against a directory pair holding just this design.
+        rm -rf fixed mobile
+        mkdir -p fixed mobile
 
-    # Parse confidence JSON
-    /usr/bin/python3 ${projectDir}/bin/parse_boltz_confidence.py \\
-        --json "boltz_results_${meta.id}/predictions/${meta.id}/confidence_${meta.id}_model_0.json" \\
-        --id "${meta.id}" \\
-        --target "${target_id}" \\
-        --binder "${binder_id}" > confidence_${meta.id}.tsv
+        # Stage the fixed structure under a design-id-aware basename so the rmsd4all `structure1`
+        # column is unique per-design (RFD3 stages every per-design RF3 output as `model.cif`,
+        # which collapses all rows to the same key and breaks downstream merges by structure1).
+        ln -s "\$(readlink -f "\$pdb_path")" "fixed/\${design_id}.\${pdb_ext}"
+        ln -s "\$(readlink -f "\$model_pdb")" "mobile/\$(basename "\$model_pdb")"
+
+        # Boltz complex PDB chain IDs are always A,B from create_boltz_yaml.py: YAML "target" slot is
+        # chain A (here: input binder sequence), YAML "binder" slot is chain B (input target sequence).
+        # Input design structure keeps original chain IDs (${target_chain}=target, ${binder_chain}=binder).
+        # Mobile must use A=binder and B=target, not the input chain letters.
+        # Target-aligned binder RMSD: superimpose on target, score binder
+        /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
+            --tm-score \\
+            --superimpose-chains ${target_chain} \\
+            --mobile-superimpose-chains B \\
+            --score-chains ${binder_chain} \\
+            --mobile-score-chains A \\
+            ${output_transformed_flag_target} \\
+            fixed/ mobile/ > "rmsd_target_aligned_binder_\${design_id}.tsv"
+
+        # Complex RMSD: Boltz mobile is A=binder, B=target. Fixed side keeps input chain IDs; when those
+        # match Boltz (e.g. rfd AF2ig A=binder B=target), order aligns. Otherwise sequence-based alignment
+        # still pairs homologous chains; target-aligned row above is the robust pose metric.
+        /usr/bin/python3 ${projectDir}/bin/rmsd4all.py \\
+            --tm-score \\
+            --superimpose-chains ${binder_chain},${target_chain} \\
+            --mobile-superimpose-chains A,B \\
+            --score-chains ${binder_chain},${target_chain} \\
+            --mobile-score-chains A,B \\
+            ${output_transformed_flag_complex} \\
+            fixed/ mobile/ > "rmsd_complex_\${design_id}.tsv"
+
+        /usr/bin/python3 ${projectDir}/bin/ipsae.py \\
+            --update-summary "\${pred_dir}/confidence_\${design_id}_model_0.json" \\
+            --binder-chain A \\
+            --target-chain B \\
+            --format boltz \\
+            "\${pred_dir}"/pae*.npz \\
+            "\${pred_dir}"/*.pdb \\
+            10 10
+
+        # Parse confidence JSON
+        /usr/bin/python3 ${projectDir}/bin/parse_boltz_confidence.py \\
+            --json "\${pred_dir}/confidence_\${design_id}_model_0.json" \\
+            --id "\${design_id}" \\
+            --target "\${design_id}_target" \\
+            --binder "\${design_id}_binder" > "confidence_\${design_id}.tsv"
+
+        # Per-design bundle. The workflow re-associates these with their meta by design id,
+        # which is what keeps batched outputs correctly paired (see BOLTZ_REFOLD_CORE).
+        # Hard links rather than copies: same filesystem, no duplicated bytes, and unlike
+        # symlinks they stay valid wherever Nextflow stages the bundle.
+        d="per_design/\${design_id}"
+        mkdir -p "\$d"
+        ln "\$model_pdb" "\$d/\${design_id}_complex.pdb"
+        ln "rmsd_target_aligned_binder_\${design_id}.tsv" "\$d/rmsd_target_aligned_binder.tsv"
+        ln "rmsd_complex_\${design_id}.tsv" "\$d/rmsd_complex.tsv"
+        ln "confidence_\${design_id}.tsv" "\$d/confidence.tsv"
+        for f in "\${pred_dir}"/*_ipsae.tsv; do
+            [[ -e "\$f" ]] && ln "\$f" "\$d/ipsae.tsv"
+        done
+        for f in "\${pred_dir}"/*_ipsae_byres.tsv; do
+            [[ -e "\$f" ]] && ln "\$f" "\$d/ipsae_byres.tsv"
+        done
+    done < .batch_manifest.tsv
+
+    rm -rf fixed mobile boltz_batch staged
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -86,6 +86,23 @@ params {
     // boltz_pulldown -> pdb).
     boltz_recycling = false
     boltz_batch_size = false
+
+    // Designs folded per Boltz REFOLD task, for both the complex and the
+    // binder-monomer comparison. Distinct from boltz_batch_size directly above,
+    // which is --diffusion_samples per Boltz job in the fold workflows; this one
+    // is how many designs share a single `boltz predict` invocation.
+    //
+    // Boltz pays a large fixed cost per invocation -- Python and torch startup
+    // plus loading the checkpoints -- which a one-design-per-task pipeline pays
+    // again for every design. Passing a directory of YAMLs to a single call
+    // amortises it: measured on a GB10 with Boltz-2 v2.2.1, 8 designs took
+    // 476.8 s as 8 invocations and 121.5 s as one, i.e. 59.6 s against 15.2 s
+    // per design, decomposing into roughly 45 s of fixed cost plus 5 s per
+    // additional design.
+    //
+    // 1 is the pre-batching behaviour exactly. The trade-off in raising it is
+    // failure granularity: a task that fails loses every design in its batch.
+    boltz_refold_batch_size = 1
     boltz_sampling_steps = false
     boltz_seed = false
     colabfold_msa_publish_name = 'result'
@@ -283,6 +300,13 @@ process {
         time = 2.hours
         memory = '8g'
         cpus = 2
+    }
+
+    // The Boltz refold comparison tasks fold --boltz_refold_batch_size designs each rather than
+    // one, so their walltime scales with the batch. At the default of 1 this is the same
+    // 2 hours the broader BOLTZ_.* selector above gives them.
+    withName: 'BOLTZ_COMPARE_COMPLEX|BOLTZ_COMPARE_BINDER_MONOMER' {
+        time = { 2.hours * Math.max(1, (params.boltz_refold_batch_size ?: 1) as int) }
     }
 
     // fold.nf (see plans/fold-nf-multi-method-folding.md) - new processes only;

--- a/subworkflows/local/boltz_refold_core.nf
+++ b/subworkflows/local/boltz_refold_core.nf
@@ -14,6 +14,10 @@ parameters: the RMSD output label (`af2ig` vs `rf3`), the BindCraft publish
 subdirectory, and whether an external target MSA (`refold_alignment`) is used.
 */
 
+// --boltz_refold_batch_size groups designs into a single `boltz predict` call; its default and
+// the measurements behind it are in nextflow.config. Read here as null-safe, so this
+// subworkflow still works if included somewhere that does not set it.
+
 include { BINDCRAFT_SCORING as BINDCRAFT_SCORING_BOLTZ_COMPLEX } from '../../modules/local/rfd/bindcraft_scoring'
 include { PDB_TO_FASTA } from '../../modules/local/common/pdb_to_fasta'
 include { BOLTZ_COMPARE_COMPLEX } from '../../modules/local/common/boltz_compare_complex'
@@ -94,31 +98,85 @@ workflow BOLTZ_REFOLD_CORE {
         }
     }
 
+    def boltz_batch_int = (params.boltz_refold_batch_size == null || params.boltz_refold_batch_size == false)
+        ? 1
+        : (params.boltz_refold_batch_size as int)
+    if (boltz_batch_int < 1) {
+        throw new Exception('--boltz_refold_batch_size must be >= 1')
+    }
+
+    // Group designs into batches, and group the target MSAs the same way so the two stay
+    // paired. The MSA channel is collated rather than joined on meta: the process never
+    // reads the staged MSA path (it is present only so a YAML can reference it by
+    // basename), the MSA belongs to the target and so is the same for every design, and
+    // collating preserves the positional pairing these two channels already relied on.
+    // The extension travels with the batch because the process stages its inputs under
+    // numbered names, which discards it (see BOLTZ_COMPARE_COMPLEX).
+    ch_complex_batches = ch_filtered_for_refold
+        .collate(boltz_batch_int, true)
+        .map { batch ->
+            tuple(
+                batch.collect { it[0] },
+                batch.collect { it[1] },
+                batch.collect { it[1].extension },
+            )
+        }
+
+    ch_target_msa_batches = ch_target_msas
+        .map { meta, target_msa -> target_msa }
+        .collate(boltz_batch_int, true)
+        .map { batch -> batch.first() }
+
     // Run Boltz complex refolding with RMSD analysis
     use_target_msa = refold_create_target_msa || refold_alignment
     BOLTZ_COMPARE_COMPLEX(
-        ch_filtered_for_refold,
+        ch_complex_batches,
         binder_chain,
         target_chain,
         use_target_msa,
         refold_use_msa_server,
-        ch_target_msas.map { meta, target_msa -> target_msa },
+        ch_target_msa_batches,
         file("${projectDir}/assets/dummy_files/empty_binder_msa"),
         file(refold_target_templates ?: "${projectDir}/assets/dummy_files/empty_templates"),
         refold_target_fasta ? file(refold_target_fasta) : "${projectDir}/assets/dummy_files/empty",
     )
 
+    // Split each batch back into per-design channels. Paths are rebuilt from the design id
+    // rather than from output order, so a batch cannot mis-pair a design with another
+    // design's results.
+    def ch_complex_per_design = BOLTZ_COMPARE_COMPLEX.out.per_design_bundle.flatMap { metas, bundle ->
+        def ml = metas instanceof List ? metas : [metas]
+        ml.collect { m -> tuple(m, file("${bundle}/${m.id}")) }
+    }
+    def ch_boltz_complex_pdb = ch_complex_per_design.map { meta, d -> tuple(meta, file("${d}/${meta.id}_complex.pdb")) }
+
     // Run Boltz binder monomer prediction with RMSD analysis
+    ch_monomer_batches = ch_filtered_for_refold
+        .join(ch_boltz_complex_pdb)
+        .collate(boltz_batch_int, true)
+        .map { batch ->
+            tuple(
+                batch.collect { it[0] },
+                batch.collect { it[1] },
+                batch.collect { it[2] },
+                batch.collect { it[1].extension },
+            )
+        }
+
     BOLTZ_COMPARE_BINDER_MONOMER(
-        ch_filtered_for_refold.join(BOLTZ_COMPARE_COMPLEX.out.pdb).map { meta, design_pdb, boltz_pdb ->
-            [meta, design_pdb, boltz_pdb]
-        },
+        ch_monomer_batches,
         binder_chain,
     )
 
+    def ch_monomer_per_design = BOLTZ_COMPARE_BINDER_MONOMER.out.per_design_bundle.flatMap { metas, bundle ->
+        def ml = metas instanceof List ? metas : [metas]
+        ml.collect { m -> tuple(m, file("${bundle}/${m.id}")) }
+    }
+    def ch_boltz_monomer_pdb = ch_monomer_per_design.map { meta, d -> tuple(meta, file("${d}/${meta.id}_monomer.pdb")) }
+
     // Aggregate RMSD outputs
-    ch_target_aligned_rmsd = BOLTZ_COMPARE_COMPLEX.out.rmsd_target_aligned
-        .map { meta, tsv_file -> tsv_file }
+    ch_target_aligned_rmsd = ch_complex_per_design
+        .map { meta, d -> file("${d}/rmsd_target_aligned_binder.tsv") }
         .collectFile(
             name: 'rmsd_target_aligned_binder.tsv',
             storeDir: "${outdir}/boltz_refold/rmsd",
@@ -126,8 +184,8 @@ workflow BOLTZ_REFOLD_CORE {
             skip: 1,
         )
 
-    ch_complex_rmsd = BOLTZ_COMPARE_COMPLEX.out.rmsd_complex
-        .map { meta, tsv_file -> tsv_file }
+    ch_complex_rmsd = ch_complex_per_design
+        .map { meta, d -> file("${d}/rmsd_complex.tsv") }
         .collectFile(
             name: "rmsd_complex_vs_${rmsd_label}.tsv",
             storeDir: "${outdir}/boltz_refold/rmsd",
@@ -135,8 +193,8 @@ workflow BOLTZ_REFOLD_CORE {
             skip: 1,
         )
 
-    ch_monomer_vs_design_rmsd = BOLTZ_COMPARE_BINDER_MONOMER.out.rmsd_monomer_vs_af2ig
-        .map { meta, tsv_file -> tsv_file }
+    ch_monomer_vs_design_rmsd = ch_monomer_per_design
+        .map { meta, d -> file("${d}/rmsd_monomer_vs_af2ig.tsv") }
         .collectFile(
             name: "rmsd_monomer_vs_${rmsd_label}.tsv",
             storeDir: "${outdir}/boltz_refold/rmsd",
@@ -144,8 +202,8 @@ workflow BOLTZ_REFOLD_CORE {
             skip: 1,
         )
 
-    ch_monomer_vs_complex_rmsd = BOLTZ_COMPARE_BINDER_MONOMER.out.rmsd_monomer_vs_complex
-        .map { meta, tsv_file -> tsv_file }
+    ch_monomer_vs_complex_rmsd = ch_monomer_per_design
+        .map { meta, d -> file("${d}/rmsd_monomer_vs_complex.tsv") }
         .collectFile(
             name: 'rmsd_monomer_vs_complex.tsv',
             storeDir: "${outdir}/boltz_refold/rmsd",
@@ -154,8 +212,8 @@ workflow BOLTZ_REFOLD_CORE {
         )
 
     // Aggregate confidence outputs
-    ch_complex_confidence = BOLTZ_COMPARE_COMPLEX.out.confidence_tsv
-        .map { meta, tsv_file -> tsv_file }
+    ch_complex_confidence = ch_complex_per_design
+        .map { meta, d -> file("${d}/confidence.tsv") }
         .collectFile(
             name: 'boltz_scores_complex.tsv',
             storeDir: "${outdir}/boltz_refold",
@@ -163,8 +221,8 @@ workflow BOLTZ_REFOLD_CORE {
             skip: 1,
         )
 
-    ch_monomer_confidence = BOLTZ_COMPARE_BINDER_MONOMER.out.confidence_tsv
-        .map { meta, tsv_file -> tsv_file }
+    ch_monomer_confidence = ch_monomer_per_design
+        .map { meta, d -> file("${d}/confidence.tsv") }
         .collectFile(
             name: 'boltz_scores_binder_monomer.tsv',
             storeDir: "${outdir}/boltz_refold",
@@ -172,12 +230,12 @@ workflow BOLTZ_REFOLD_CORE {
             skip: 1,
         )
 
-    ch_ipsae_tsv = BOLTZ_COMPARE_COMPLEX.out.ipsae_tsv
-    ch_ipsae_byres_tsv = BOLTZ_COMPARE_COMPLEX.out.ipsae_byres_tsv
+    ch_ipsae_tsv = ch_complex_per_design.map { meta, d -> tuple(meta, file("${d}/ipsae.tsv")) }
+    ch_ipsae_byres_tsv = ch_complex_per_design.map { meta, d -> tuple(meta, file("${d}/ipsae_byres.tsv")) }
 
     // BindCraft-score the Boltz-2 refolded complexes
     BINDCRAFT_SCORING_BOLTZ_COMPLEX(
-        BOLTZ_COMPARE_COMPLEX.out.pdb.map { meta, pdb -> pdb },
+        ch_boltz_complex_pdb.map { meta, pdb -> pdb },
         binder_chain,
         'default_4stage_multimer',
         bindcraft_publish_subdir,
@@ -200,6 +258,6 @@ workflow BOLTZ_REFOLD_CORE {
     boltz_extra_scores = ch_extra_scores
     ipsae_tsv = ch_ipsae_tsv
     ipsae_byres_tsv = ch_ipsae_byres_tsv
-    boltz_complex_pdb = BOLTZ_COMPARE_COMPLEX.out.pdb
-    boltz_monomer_pdb = BOLTZ_COMPARE_BINDER_MONOMER.out.pdb
+    boltz_complex_pdb = ch_boltz_complex_pdb
+    boltz_monomer_pdb = ch_boltz_monomer_pdb
 }

--- a/workflows/rfd3.nf
+++ b/workflows/rfd3.nf
@@ -247,6 +247,7 @@ workflow RFD3 {
         Full refolding options (Boltz-2):
             --full_refold_with         Comma-separated list of refolding methods (valid options: 'boltz') [default: ${params.full_refold_with}]
             --full_refold_max          Maximum designs to refold [default: ${params.full_refold_max}]
+            --boltz_refold_batch_size  Designs per Boltz refold task; >1 amortises Boltz model loading over the batch [default: ${params.boltz_refold_batch_size}]
             --full_refold_filter_sort  Metric to sort by before refolding. Use '-' prefix for descending. [default: ${params.full_refold_filter_sort}]
             --full_refold_create_target_msa  Create target MSA for refolding (runs MMseqs2) [default: ${params.full_refold_create_target_msa}]
             --full_refold_alignment    External A3M file for refold target; bypasses MMseqs2 when set [default: ${params.full_refold_alignment}]


### PR DESCRIPTION
## What

Adds `--boltz_refold_batch_size` (default 1), which groups designs into a single `boltz predict` invocation for both the complex and the binder-monomer refold comparisons.

## Why

Boltz pays a large fixed cost per invocation - Python and torch startup plus loading the checkpoints - which a one-design-per-task pipeline pays again for every design. Passing a directory of YAMLs to one call amortises it.

Measured on a GB10 with Boltz-2 v2.2.1, folding the same 8 binder monomers:

| | total wall | per design |
|---|---|---|
| 8 separate invocations | 476.8 s | 59.6 s |
| 1 batched invocation | 121.5 s | **15.2 s** |

The per-item progress inside the batch decomposes this into roughly **45 s of fixed cost plus ~5 s per additional design**, so the gain keeps growing with batch size and flattens out somewhere past 16.

For context on where that 45 s goes: on this host the container image is a squashfs mounted through `squashfuse_ll`, and reading the 4.2 GB of Boltz checkpoints costs 15.3 s wall / 20.2 s CPU through it against 1.1 s / 0.14 s from a bind-mounted host directory. Batching removes most of that cost regardless of how the weights are served, because it stops paying it per design.

## How

Each task now takes a list of designs, writes one YAML per design into a single input directory, runs `boltz predict` once over it, then **reshapes the output back into the per-design `boltz_results_<design_id>/predictions/<design_id>/` layout these modules have always emitted**. `publishDir` patterns and every downstream path are therefore unchanged, and at the default batch size of 1 the published tree is what it was before (including the `msa/`, `processed/` and `lightning_logs/` siblings, hard-linked rather than copied).

Results travel back to the workflow in a `per_design/` bundle, following the pattern `ROSETTAFOLD3` already uses for `--rf3_batch_size`. The workflow rebuilds paths from the design id rather than from output order, so a batch cannot mis-pair a design with another design's results.

## Two things worth a reviewer's attention

**Inputs are staged under numbered names** (`design_inputs/input1`, `input2`, ...) rather than their own. Nextflow refuses to stage two files sharing a basename in one collection, and RFD3 hands every design's RF3 output over as `model.cif` - so the natural `stageAs: 'dir/*'` collides as soon as a batch holds more than one design. This was caught by testing, not by reading. The numbered wildcard preserves input order, which is what pairs each staged file with its meta; real extensions travel alongside in a `val` list since the wildcard discards them, and each input is linked back to `<design_id>.<ext>` inside the task.

**The parameter is `--boltz_refold_batch_size`, not `--boltz_batch_size`.** The latter already exists and means `--diffusion_samples` per Boltz job in the `fold` workflows. Reusing the name would have silently coupled two unrelated knobs.

## Testing

Run on 4 designs whose structures are all named `model.cif`, reproducing the RFD3 case, at batch sizes 1 and 4:

- same output file inventory, same published tree shape, same column counts
- each design's scores track its own counterpart, and the relative ordering of designs is preserved

Boltz seeds nothing by default (`--seed` defaults to None), so runs are not bit-reproducible. The control for that: **two runs at batch size 1 differ from each other by as much as batch 1 differs from batch 4.**

| column | b1 run A vs run B (same config) | b1 vs b4 |
|---|---|---|
| iptm | 0.0877 | 0.0798 |
| ipsae_min | 0.1932 | 0.1729 |
| complex_plddt | 0.0199 | 0.0086 |
| overall max abs diff | 0.9018 | 0.9215 |

So batching introduces no difference beyond Boltz's own nondeterminism.

Not covered by the test: BindCraft scoring downstream was allowed to fail in the harness for an unrelated reason (it hardcodes `/opt/conda/envs/BindCraft`, which the image used here does not have), so this PR does not exercise that path.

## Trade-off

Raising the batch size coarsens failure granularity: a task that fails loses every design in its batch. Default stays at 1, which is the previous behaviour exactly.